### PR TITLE
Rename Piwik to Matomo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -192,7 +192,7 @@
                    <li class="mdl-list__item">
                     <span class="mdl-list__item-primary-content">
                       <img src="images/piwik.png" alt="Piwik logo" class="thirdparty-logo">
-                      Piwik
+                      Matomo (formerly Piwik)
                     </span>
                     <span class="mdl-list__item-secondary-action">
                       <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="list-switch-piwik">
@@ -244,7 +244,7 @@
                       <li v-if="crashlytics">
                         <a href="http://try.crashlytics.com/terms/privacy-policy.pdf" target="_blank">Crashlytics</a>
                       </li>
-                       <li v-if="piwik"><a href="https://piwik.org/privacy-policy/" target="_blank">Piwik</a></li>
+                       <li v-if="piwik"><a href="https://matomo.org/privacy-policy/" target="_blank">Matomo</a></li>
                     </ul>
                   </div>
                   <p><strong>Log Data</strong></p>


### PR DESCRIPTION
As per Piwik/Matomo's [official blog post](https://matomo.org/blog/2018/01/piwik-is-now-matomo/), Piwik is now called Matomo. It is important that we reflect this change, as any failure to do so could lead to ambiguity in the generated privacy policies themselves.

To prevent users from being confused, Matomo is listed in the selection menu as `Matomo (formerly Piwik)`.

See here: https://matomo.org/blog/2018/01/piwik-is-now-matomo/