### PR TITLE
Add missing space in T&C final paragraph.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -331,7 +331,7 @@
                         you experience as a result of relying wholly on this functionality of the app.</p>
 
                       <p>At some point, we may wish to update the app. The app is currently available on {{osType}} – the
-                        requirements for {{requirementOfSystem}}(and for any additional systems we decide to extend the availability
+                        requirements for {{requirementOfSystem}} (and for any additional systems we decide to extend the availability
                         of the app to) may change, and you’ll need to download the updates if you want to keep using the
                         app. {{devOrCompanyName}} does not promise that it will always update the app so that it is relevant
                         to you and/or works with the {{osType}} version that you have installed on your device. However,


### PR DESCRIPTION
Currently generate to: `...requirements for both systems(and for any...`. This adds a space before the `(` to make it: `...requirements for both systems (and for any...`