### PR TITLE
Fix grammar issues

### DIFF
--- a/src/includes/content/privacy_policy/simple.pug
+++ b/src/includes/content/privacy_policy/simple.pug
@@ -25,7 +25,7 @@
           | anyone except as described in this Privacy Policy.
         p
           | The terms used in this Privacy Policy have the same meanings
-          | as in our Terms and Conditions, which is accessible at
+          | as in our Terms and Conditions, which are accessible at
           | {{ appName }} unless otherwise defined in this Privacy Policy.
         p
           strong Information Collection and Use
@@ -36,10 +36,10 @@
           | {{iOrWe}} request will be {{retainedInfo}}.
         div(v-if='hasThirdPartyServicesSelected')
           p
-            | The app does use third party services that may collect
+            | The app does use third-party services that may collect
             | information used to identify you.
           p
-            | Link to privacy policy of third party service providers used
+            | Link to the privacy policy of third-party service providers used
             | by the app
           ul
             li(v-if='item[item.model] && item.link.privacy' v-for='item in thirdPartyServices')
@@ -49,7 +49,7 @@
         p
           | {{iOrWe | capitalize }} want to inform you that whenever you
           | use {{myOrOur}} Service, in a case of an error in the app
-          | {{iOrWe}} collect data and information (through third party
+          | {{iOrWe}} collect data and information (through third-party
           | products) on your phone called Log Data. This Log Data may
           | include information such as your device Internet Protocol
           | (&ldquo;IP&rdquo;) address, device name, operating system version, the
@@ -65,7 +65,7 @@
           | stored on your device&apos;s internal memory.
         p
           | This Service does not use these &ldquo;cookies&rdquo; explicitly. However,
-          | the app may use third party code and libraries that use
+          | the app may use third-party code and libraries that use
           | &ldquo;cookies&rdquo; to collect information and improve their services.
           | You have the option to either accept or refuse these cookies
           | and know when a cookie is being sent to your device. If you
@@ -83,7 +83,7 @@
           li To assist us in analyzing how our Service is used.
         p
           | {{iOrWe | capitalize }} want to inform users of this Service
-          | that these third parties have access to your Personal
+          | that these third parties have access to their Personal
           | Information. The reason is to perform the tasks assigned to
           | them on our behalf. However, they are obligated not to
           | disclose or use the information for any other purpose.
@@ -119,7 +119,7 @@
             | delete this from our servers. If you are a parent or guardian
             | and you are aware that your child has provided us with
             | personal information, please contact {{ meOrUs }} so that
-            | {{ iOrWe }} will be able to do necessary actions.
+            | {{ iOrWe }} will be able to do the necessary actions.
         div(v-if='!hasThirdPartyServicesSelected')
           p
             | {{iOrWe | capitalize }} do not knowingly collect personally

--- a/src/includes/content/tnc/simple.pug
+++ b/src/includes/content/tnc/simple.pug
@@ -11,12 +11,12 @@
           | By downloading or using the app, these terms will
           | automatically apply to you &ndash; you should make sure therefore
           | that you read them carefully before using the app. You&rsquo;re not
-          | allowed to copy, or modify the app, any part of the app, or
+          | allowed to copy or modify the app, any part of the app, or
           | our trademarks in any way. You&rsquo;re not allowed to attempt to
           | extract the source code of the app, and you also shouldn&rsquo;t try
-          | to translate the app into other languages, or make derivative
-          | versions. The app itself, and all the trade marks, copyright,
-          | database rights and other intellectual property rights related
+          | to translate the app into other languages or make derivative
+          | versions. The app itself, and all the trademarks, copyright,
+          | database rights, and other intellectual property rights related
           | to it, still belong to {{devOrCompanyName}}.
         p
           | {{devOrCompanyName}} is committed to ensuring that the app is
@@ -27,7 +27,7 @@
           | clear to you exactly what you&rsquo;re paying for.
         p
           | The {{appName}} app stores and processes personal data that
-          | you have provided to us, in order to provide {{myOrOur}}
+          | you have provided to us, to provide {{myOrOur}}
           | Service. It&rsquo;s your responsibility to keep your phone and
           | access to the app secure. We therefore recommend that you do
           | not jailbreak or root your phone, which is the process of
@@ -38,10 +38,10 @@
           | that the {{appName}} app won&rsquo;t work properly or at all.
         div(v-if='hasThirdPartyServicesSelected')
           p
-            | The app does use third party services that declare their own
+            | The app does use third-party services that declare their
             | Terms and Conditions.
           p
-            | Link to Terms and Conditions of third party service
+            | Link to Terms and Conditions of third-party service
             | providers used by the app
           ul
             li(v-if='item[item.model] && item.link.terms' v-for='item in thirdPartyServices')
@@ -50,7 +50,7 @@
           | You should be aware that there are certain things that
           | {{devOrCompanyName}} will not take responsibility for. Certain
           | functions of the app will require the app to have an active
-          | internet connection. The connection can be Wi-Fi, or provided
+          | internet connection. The connection can be Wi-Fi or provided
           | by your mobile network provider, but {{devOrCompanyName}}
           | cannot take responsibility for the app not working at full
           | functionality if you don&rsquo;t have access to Wi-Fi, and you don&rsquo;t
@@ -58,11 +58,11 @@
         p
         p
           | If you&rsquo;re using the app outside of an area with Wi-Fi, you
-          | should remember that your terms of the agreement with your
+          | should remember that the terms of the agreement with your
           | mobile network provider will still apply. As a result, you may
           | be charged by your mobile provider for the cost of data for
           | the duration of the connection while accessing the app, or
-          | other third party charges. In using the app, you&rsquo;re accepting
+          | other third-party charges. In using the app, you&rsquo;re accepting
           | responsibility for any such charges, including roaming data
           | charges if you use the app outside of your home territory
           | (i.e. region or country) without turning off data roaming. If
@@ -78,7 +78,7 @@
         p
           | With respect to {{devOrCompanyName}}&rsquo;s responsibility for your
           | use of the app, when you&rsquo;re using the app, it&rsquo;s important to
-          | bear in mind that although we endeavour to ensure that it is
+          | bear in mind that although we endeavor to ensure that it is
           | updated and correct at all times, we do rely on third parties
           | to provide information to us so that we can make it available
           | to you. {{devOrCompanyName}} accepts no liability for any
@@ -86,7 +86,7 @@
           | relying wholly on this functionality of the app.
         p
           | At some point, we may wish to update the app. The app is
-          | currently available on {{osType}} &ndash; the requirements for
+          | currently available on {{osType}} &ndash; the requirements for the 
           | {{requirementOfSystem}}(and for any additional systems we
           | decide to extend the availability of the app to) may change,
           | and you&rsquo;ll need to download the updates if you want to keep


### PR DESCRIPTION
Fixes issue #110 

Used grammarly on the Privacy Policy template:

![Screenshot 2021-07-25 at 19 53 13](https://user-images.githubusercontent.com/2096087/126908504-40243a75-affa-40fb-856b-9da85a566e64.png)

Used grammarly on the T&C  template:
![Screenshot 2021-07-25 at 20 03 39](https://user-images.githubusercontent.com/2096087/126908801-ca7b0849-a63a-4147-8c29-2ddc82df37e5.png)

